### PR TITLE
Changed the hrms version from the found one due to build failure

### DIFF
--- a/ci/apps.json
+++ b/ci/apps.json
@@ -9,7 +9,7 @@
   }, 
   {
     "url": "https://github.com/frappe/hrms.git",
-    "branch": "v15.25.2"
+    "branch": "v15.26.0"
   },
   {
     "url": "https://github.com/frappe/lms.git",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0a008a65-8863-4669-a2bb-354a789a711b)


Changed the hrms version to v15.26.0, since the build bug is fixed in it
https://github.com/frappe/hrms/issues/2030