### PR TITLE
Fix : Changed image name to create correct  package

### DIFF
--- a/ci/build.env
+++ b/ci/build.env
@@ -1,7 +1,7 @@
 REGISTRY=ghcr.io
 PROJECT_NAMESPACE=lmnaslimited
 PROJECT_NAME=lensdocker
-IMAGE=lenshxm
+IMAGE=lenslumi-ind
 FRAPPE_REPO=https://github.com/frappe/frappe
 FRAPPE_VERSION=v15.44.2
 PY_VERSION=3.11.6


### PR DESCRIPTION
In last PR #89 the image name is wrong. hence the package lenslumi-ind is not created.