### PR TITLE
Fix : lenscx v15.69.1 version is build with new dockerfile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build Image
 on:
   push:
     branches:
-      - lenscx
+      - lenscx-versionv15.69.1
 
   workflow_dispatch:
     inputs:

--- a/ci/build.env
+++ b/ci/build.env
@@ -6,5 +6,5 @@ FRAPPE_REPO=https://github.com/frappe/frappe
 FRAPPE_VERSION=v15.69.1
 PY_VERSION=3.11.6
 NODEJS_VERSION=18.18.2
-CONTEXT=git://github.com/lmnaslimited/frappe_docker
+CONTEXT=git://github.com/lmnaslimited/frappe_docker#container-versionv15.69.1
 DOCKERFILE=images/custom/Containerfile


### PR DESCRIPTION
lenscx-versionv15.69.1 is checkout from base branch "lenscx"
lenscx-versionv15.69.1 is pointing to dockerfile in lmnaslimited/frappe_docker (branch : container_versionv15.69.1)

