### PR TITLE
Fix : HRMS patch hook failure

### DIFF
--- a/ci/apps.json
+++ b/ci/apps.json
@@ -9,7 +9,7 @@
   }, 
   {
     "url": "https://github.com/frappe/hrms.git",
-    "branch": "v15.46.0"
+    "branch": "v15.46.1"
   },
   {
     "url": "https://github.com/frappe/lms.git",


### PR DESCRIPTION
In HRMS version v15.46.0 (May 28, 2025) -> When executing patch for hrms attendance encountering an error

Fix : In HRMS version v15.46.1 (May 29, 2025)