### PR TITLE
Changed the dockerfile context

### DIFF
--- a/ci/build.env
+++ b/ci/build.env
@@ -6,5 +6,5 @@ FRAPPE_REPO=https://github.com/frappe/frappe
 FRAPPE_VERSION=v16.14.0
 PY_VERSION=3.14.2
 NODEJS_VERSION=24.13.0
-CONTEXT=git://github.com/frappe/frappe_docker
+CONTEXT=git://github.com/lmnaslimited/frappe_docker
 DOCKERFILE=images/custom/Containerfile


### PR DESCRIPTION
Root Cause : During Image build the apps in the apps.json is not installed and build.

Reason : For dockerfile we used official frappe_docker one (https://github.com/frappe/frappe_docker/blob/main/images/custom/Containerfile)
In this lastest file they have removed passing apps.json as build-arg,

Since from the setuptool problem we are using our forked version of frappe_docker, hence this is not happened for other release groups.
ours -> https://github.com/lmnaslimited/frappe_docker/blob/container-versionv15.69.1/images/custom/Containerfile