### PR TITLE
Changed from Kaniko to docker buildx due to disk space

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,9 +28,6 @@ on:
       apps-json-base64:
         description: base64 encoded string of apps.json
         type: string
-      context:
-        description: kaniko context
-        type: string
       dockerfile:
         description: dockerfile path from context
         type: string
@@ -48,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Source Build Env
         id: source-build-env
@@ -57,24 +54,36 @@ jobs:
           echo "VERSION=$(cat ./ci/version.txt)" >> $GITHUB_ENV
           echo "APPS_JSON_BASE64=$(base64 -w 0 ./ci/apps.json)" >> $GITHUB_ENV
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ inputs.registry || env.REGISTRY }}
           username: ${{ inputs.registry-user || github.actor }}
           password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
-      - uses: int128/kaniko-action@v1
+      - name: Build and Push Image
+        uses: docker/build-push-action@v5
         with:
+          context: ${{ env.CONTEXT }}
+          file: ${{ env.DOCKERFILE }}
           push: true
-          cache: true
-          kaniko-args: |
-            --build-arg=FRAPPE_PATH=${{ inputs.frappe-repo || env.FRAPPE_REPO }}
-            --build-arg=FRAPPE_BRANCH=${{ inputs.frappe-version || env.FRAPPE_VERSION }}
-            --build-arg=PYTHON_VERSION=${{ inputs.py-version || env.PY_VERSION }}
-            --build-arg=NODE_VERSION=${{ inputs.nodejs-version || env.NODEJS_VERSION }}
-            --build-arg=APPS_JSON_BASE64=${{ inputs.apps-json-base64 || env.APPS_JSON_BASE64 }}
-            --context=${{ inputs.context || env.CONTEXT }}
-            --destination=ghcr.io/${{ github.repository }}/${{ inputs.image || env.IMAGE }}:${{ inputs.version || env.VERSION }}
-            --destination=ghcr.io/${{ github.repository }}/${{ inputs.image || env.IMAGE }}:latest
-          file: ${{ inputs.dockerfile || env.DOCKERFILE }}
+          tags: |
+            ghcr.io/${{ github.repository }}/${{ inputs.image || env.IMAGE }}:${{ inputs.version || env.VERSION }}
+            ghcr.io/${{ github.repository }}/${{ inputs.image || env.IMAGE }}:latest
+          build-args: |
+            FRAPPE_PATH=${{ inputs.frappe-repo || env.FRAPPE_REPO }}
+            FRAPPE_BRANCH=${{ inputs.frappe-version || env.FRAPPE_VERSION }}
+            PYTHON_VERSION=${{ inputs.py-version || env.PY_VERSION }}
+            NODE_VERSION=${{ inputs.nodejs-version || env.NODEJS_VERSION }}
+            APPS_JSON_BASE64=${{ inputs.apps-json-base64 || env.APPS_JSON_BASE64 }}

--- a/ci/build.env
+++ b/ci/build.env
@@ -6,5 +6,5 @@ FRAPPE_REPO=https://github.com/frappe/frappe
 FRAPPE_VERSION=v15.101.5
 PY_VERSION=3.12.8
 NODEJS_VERSION=22.14.0
-CONTEXT=git://github.com/lmnaslimited/frappe_docker#container-versionv15.69.1
+CONTEXT=https://github.com/lmnaslimited/frappe_docker.git#container-versionv15.69.1
 DOCKERFILE=images/custom/Containerfile


### PR DESCRIPTION
The Github action is exit with code 137

Reason:
In Linux-based environments like Docker, Kubernetes, or GitHub Actions, Exit Code 137 means that a process was abruptly and forcefully terminated by the system using a SIGKILL (Signal 9).
Standard [GitHub](https://github.com/)-hosted Linux runners provide 7 GB of RAM for public repositories but only 14 GB of RAM for larger standard tasks, which can be filled surprisingly quickly by modern compilers, test suites, or build tools.